### PR TITLE
Fix get_bill service failure when email is provided (#21)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.1.3] - 2026-04-28
+
+### Fixed
+
+ - Исправлена ошибка вызова сервиса `mygas.get_bill` с указанием email: схема использовала `vol.Email` без скобок, из-за чего вместо валидации значение поля становилось функцией и сервис падал с `Type is not JSON serializable: function` ([#21](https://github.com/lizardsystems/hass-mygas/issues/21)).
+
 ## [2.1.2] - 2026-03-19
 
 ### Fixed

--- a/custom_components/mygas/manifest.json
+++ b/custom_components/mygas/manifest.json
@@ -15,5 +15,5 @@
   "requirements": [
     "aiomygas==2.4"
   ],
-  "version": "2.1.2"
+  "version": "2.1.3"
 }

--- a/custom_components/mygas/services.py
+++ b/custom_components/mygas/services.py
@@ -56,7 +56,7 @@ SERVICE_GET_BILL_SCHEMA = vol.Schema(
     {
         **SERVICE_BASE_SCHEMA,
         vol.Optional(ATTR_DATE): cv.date,
-        vol.Optional(ATTR_EMAIL): vol.Email,
+        vol.Optional(ATTR_EMAIL): vol.Email(),
     },
 )
 

--- a/tests/test_get_bill.py
+++ b/tests/test_get_bill.py
@@ -9,7 +9,7 @@ from homeassistant.helpers import device_registry as dr
 from homeassistant.util import dt as dt_util
 from pytest_homeassistant_custom_component.common import MockConfigEntry
 
-from custom_components.mygas.const import DOMAIN
+from custom_components.mygas.const import DOMAIN, SERVICE_GET_BILL
 from custom_components.mygas.helpers import make_account_device_id
 
 from .const import MOCK_LSPU_INFO_NO_BALANCES, MOCK_LSPU_INFO_RESPONSE
@@ -113,3 +113,42 @@ async def test_get_bill_with_explicit_date(
     mock_api.async_get_receipt.assert_called_once()
     call_args = mock_api.async_get_receipt.call_args
     assert call_args[0][0] == "2025-06-15"
+
+
+# ---------------------------------------------------------------------------
+# Service call with email passes schema validation (regression for issue #21)
+# ---------------------------------------------------------------------------
+
+
+async def test_get_bill_service_with_email(
+    hass: HomeAssistant,
+    mock_config_entry: MockConfigEntry,
+    mock_auth: AsyncMock,
+    mock_api: AsyncMock,
+) -> None:
+    """Service call with email must validate to a string, not a function.
+
+    Regression for issue #21: vol.Email (without parens) is a factory; using
+    it directly turned the validated email into a function reference, which
+    later failed JSON serialization with "Type is not JSON serializable: function".
+    """
+    mock_config_entry.add_to_hass(hass)
+    await hass.config_entries.async_setup(mock_config_entry.entry_id)
+    await hass.async_block_till_done()
+
+    device = _get_account_device(hass)
+
+    await hass.services.async_call(
+        DOMAIN,
+        SERVICE_GET_BILL,
+        {
+            "device_id": device.id,
+            "date": "2026-04-27",
+            "email": "user@example.com",
+        },
+        blocking=True,
+    )
+
+    mock_api.async_get_receipt.assert_called_once()
+    call_args = mock_api.async_get_receipt.call_args
+    assert call_args[0][1] == "user@example.com"


### PR DESCRIPTION
## Summary

Fixes #21. The `mygas.get_bill` service failed with `Type is not JSON serializable: function` whenever an `email` was supplied; without email it worked.

Root cause in `custom_components/mygas/services.py`:

```python
vol.Optional(ATTR_EMAIL): vol.Email,   # missing parens
```

`vol.Email` is a validator **factory** (decorated with `@message`), not a validator. Used bare, voluptuous calls `vol.Email(email_string)` during validation, which voluptuous interprets as setting the error-message parameter and returns a wrapper *function*. That function reference leaked into `service_call.data["email"]`, then later failed JSON serialization (and `unquote(email)` on a function would also raise).

Fix: invoke the factory with `vol.Email()`, matching the docstring example `Schema(Email())`.

## Test plan

- [x] Added regression test `test_get_bill_service_with_email` that calls the service through `hass.services.async_call` so the schema is exercised.
- [x] Verified the new test fails on the unfixed code (`argument of type 'function' is not iterable`) and passes after the fix.
- [x] `pytest tests/ -v` -- 58 passed.